### PR TITLE
Timeline corrections

### DIFF
--- a/src/components/metadata/MetadataDetails.tsx
+++ b/src/components/metadata/MetadataDetails.tsx
@@ -98,7 +98,6 @@ const MetadataDetails: React.FC<MetadataDetailsProps> = ({
   }));
 
 function formatRuntime(runtime: string): string {
-  // Match formats like "1h55min" or "2h 7min" and convert to "1H 55M" or "2H 7M"
   // Try to match formats like "1h55min", "2h 7min", "125 min", etc.
   const match = runtime.match(/(?:(\d+)\s*h\s*)?(\d+)\s*min/i);
   if (match) {

--- a/src/components/metadata/MetadataDetails.tsx
+++ b/src/components/metadata/MetadataDetails.tsx
@@ -98,11 +98,35 @@ const MetadataDetails: React.FC<MetadataDetailsProps> = ({
   }));
 
 function formatRuntime(runtime: string): string {
+  // Match formats like "1h55min" or "2h 7min" and convert to "1H 55M" or "2H 7M"
+  // Try to match formats like "1h55min", "2h 7min", "125 min", etc.
+  const match = runtime.match(/(?:(\d+)\s*h\s*)?(\d+)\s*min/i);
+  if (match) {
+    const h = match[1] ? parseInt(match[1], 10) : 0;
+    const m = match[2] ? parseInt(match[2], 10) : 0;
+    if (h > 0) {
+      return `${h}H ${m}M`;
+    }
+    if (m < 60) {
+      return `${m} MIN`;
+    }
+    const hours = Math.floor(m / 60);
+    const mins = m % 60;
+    return hours > 0 ? `${hours}H ${mins}M` : `${mins} MIN`;
+  }
+
+  // Fallback: treat as minutes if it's a number
   const r = parseInt(runtime, 10);
-  if (isNaN(r) || r < 60) return runtime;
-  const h = Math.floor(r / 60);
-  const m = r % 60;
-  return `${h}H ${m}MIN`;
+  if (!isNaN(r)) {
+    if (r < 60) return `${r} MIN`;
+    const h = Math.floor(r / 60);
+    const m = r % 60;
+    return h > 0 ? `${h}H ${m}M` : `${m} MIN`;
+  }
+
+  // If not matched, return as is
+  return runtime;
+  
 }
 
   return (

--- a/src/components/metadata/MetadataDetails.tsx
+++ b/src/components/metadata/MetadataDetails.tsx
@@ -262,7 +262,7 @@ const styles = StyleSheet.create({
   metaInfo: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 12,
+    gap: 18,
     paddingHorizontal: 16,
     marginBottom: 12,
   },


### PR DESCRIPTION
- Fixing logic on TMDB catalogs where it was not adding space between H and M
- Increased gap between metadata to make it easier to read
- Changed from H and MIN to H and M. MIN is still present where it is lower than 60 minutes

Fixes #160